### PR TITLE
Fix split_term_style

### DIFF
--- a/cp.vim
+++ b/cp.vim
@@ -26,6 +26,7 @@ function! TermWrapper(command) abort
 	if exists('g:split_term_resize_cmd')
 		exec g:split_term_resize_cmd
 	endif
+	exec buffercmd
 	exec 'term ' . a:command
 	exec 'startinsert'
 endfunction


### PR DESCRIPTION
Thanks for making your config open source. It is super awesome!

I really wanted to split my terminal vertically but changing `split_term_style` did not help. I then figured out that `buffercmd` variable is not actually used.

